### PR TITLE
Add support for 2021-05-07 Raspberry Pi OS Lite image

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,9 @@ Base image to use.
 
 The following values are allowed:
 - `raspbian_lite:2020-02-13`
-- `raspios_lite:2021-03-04` (default)
+- `raspios_lite:2021-03-04`
+- `raspios_lite:2021-05-07` (default)
+- `dietpi:rpi_armv6_buster`
 
 More images will be added, eventually. Feel free to submit PRs.
 

--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,7 @@ inputs:
   base_image:
     description: 'System base image'
     required: true
-    default: 'raspios_lite:2021-03-04'
+    default: 'raspios_lite:2021-05-07'
   image_additional_mb:
     description: 'Additional MB for image'
     required: false
@@ -68,11 +68,12 @@ runs:
             repository_name=`basename ${{ github.workspace }}`
             repository_path=/${repository_name}
         fi
+        sudo mkdir -p $(dirname ${{ steps.mount_image.outputs.mount }}${repository_path})
         sudo cp -Rp ${{ github.workspace }} ${{ steps.mount_image.outputs.mount }}${repository_path}
         sudo touch ${{ steps.mount_image.outputs.mount }}/tmp/commands.sh
         sudo chmod o+wx ${{ steps.mount_image.outputs.mount }}/tmp/commands.sh
         echo "#!/bin/sh" > ${{ steps.mount_image.outputs.mount }}/tmp/commands.sh
-        echo "set -e" >> ${{ steps.mount_image.outputs.mount }}/tmp/commands.sh
+        echo "set -ex" >> ${{ steps.mount_image.outputs.mount }}/tmp/commands.sh
         echo "cd ${repository_path}" >> ${{ steps.mount_image.outputs.mount }}/tmp/commands.sh
         cat >> ${{ steps.mount_image.outputs.mount }}/tmp/commands.sh <<"ARM_RUNNER_INPUT_COMMANDS_EOF"
         ${{ inputs.commands }}

--- a/download_image.sh
+++ b/download_image.sh
@@ -4,9 +4,19 @@ set -uo pipefail
 case $1 in
     "raspbian_lite:2020-02-13")
         url=https://downloads.raspberrypi.org/raspbian_lite/images/raspbian_lite-2020-02-14/2020-02-13-raspbian-buster-lite.zip
+        uncompress="unzip -u"
     ;;
     "raspios_lite:2021-03-04")
         url=https://downloads.raspberrypi.org/raspios_lite_armhf/images/raspios_lite_armhf-2021-03-25/2021-03-04-raspios-buster-armhf-lite.zip
+        uncompress="unzip -u"
+    ;;
+    "raspios_lite:2021-05-07")
+        url=https://downloads.raspberrypi.org/raspios_lite_armhf/images/raspios_lite_armhf-2021-05-28/2021-05-07-raspios-buster-armhf-lite.zip
+        uncompress="unzip -u"
+    ;;
+    "dietpi:rpi_armv6_buster")
+        url=https://dietpi.com/downloads/images/DietPi_RPi-ARMv6-Buster.7z
+        uncompress="7zr e"
     ;;
     *)
     echo "Unknown image $1"
@@ -19,6 +29,6 @@ tempdir=${RUNNER_TEMP:-/home/actions/temp}/arm-runner
 mkdir -p ${tempdir}
 cd ${tempdir}
 wget -q ${url}
-unzip -u ${filename}
-mv "$(ls *.img | head -n 1)" arm-runner.img
+${uncompress} ${filename}
+mv "$(ls *.img */*.img 2>/dev/null | head -n 1)" arm-runner.img
 echo "::set-output name=image::${tempdir}/arm-runner.img"


### PR DESCRIPTION
Resolves #1.
Also adds support for DietPi RPi-ARMv6-Buster image.