### PR TITLE
Add support for raspios_lite:2022-01-28 image

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Commands to execute. Written to a script within the image. Required.
 
 #### `base_image`
 
-Base image to use. By default, uses latest `raspio_lite` image. Please note
+Base image to use. By default, uses latest `raspios_lite` image. Please note
 that this is not necessarily well suited for continuous integration as
 the latest image can change with new releases.
 
@@ -77,7 +77,7 @@ The following values are allowed:
 - `raspios_lite:2021-03-04`
 - `raspios_lite:2021-05-07`
 - `raspios_lite:2021-10-30`
-- `raspios_lite:2021-11-08`
+- `raspios_lite:2022-01-28`
 - `raspios_lite:latest` (armhf build, default)
 - `dietpi:rpi_armv6_bullseye`
 

--- a/download_image.sh
+++ b/download_image.sh
@@ -22,8 +22,8 @@ case $1 in
     "raspios_lite:2021-10-30")
         url=https://downloads.raspberrypi.org/raspios_lite_armhf/images/raspios_lite_armhf-2021-11-08/2021-10-30-raspios-bullseye-armhf-lite.zip
     ;;
-    "raspios_lite:2021-11-08")
-        url=https://downloads.raspberrypi.org/raspios_lite_armhf/images/raspios_lite_armhf-2021-11-08/2021-10-30-raspios-bullseye-armhf-lite.zip
+    "raspios_lite:2022-01-28")
+        url=https://downloads.raspberrypi.org/raspios_lite_armhf/images/raspios_lite_armhf-2022-01-28/2022-01-28-raspios-bullseye-armhf-lite.zip
     ;;
     "dietpi:rpi_armv6_bullseye")
         url=https://dietpi.com/downloads/images/DietPi_RPi-ARMv6-Bullseye.7z


### PR DESCRIPTION
Add support for `raspios_lite:2022-01-28` image.
Also remove _zombie_ `raspios_lite:2021-11-08` image (which is in fact `raspios_lite:2021-10-30`).