### PR TITLE
Download gzip image

### DIFF
--- a/.github/workflows/test-gzip_image.yml
+++ b/.github/workflows/test-gzip_image.yml
@@ -1,0 +1,13 @@
+name: Test gzip image
+on: [push, pull_request, workflow_dispatch]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ./ # pguyot/arm-runner-action@HEAD
+      with:
+        base_image: https://github.com/radxa/rock-pi-s-images-released/releases/download/rock-pi-s-v20210924/rockpis_debian_buster_server_arm64_20210924_0412-gpt.img.gz
+        cpu: cortex-a53
+        commands: |
+          ls /boot/config-*-rockchip*

--- a/download_image.sh
+++ b/download_image.sh
@@ -72,6 +72,9 @@ case $url in
     *.xz)
         uncompress="xz -d"
     ;;
+    *.gz)
+        uncompress="gzip -d"
+    ;;
 esac
 
 filename=`basename ${url}`


### PR DESCRIPTION
I'm attempting to use this action to create an image for a Rock Pi S. The images [on their Github page](https://github.com/radxa/rock-pi-s-images-released/releases) are `.gz` files and this seems to be fairly common for disk images from what I've seen.