### PR TITLE
Support expanding GPT partition table

### DIFF
--- a/.github/workflows/test-gpt-partition-table.yml
+++ b/.github/workflows/test-gpt-partition-table.yml
@@ -1,0 +1,14 @@
+name: Test expand GPT partition table
+on: [push, pull_request, workflow_dispatch]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./ # pguyot/arm-runner-action@HEAD
+        with:
+          base_image: https://github.com/radxa/rock-pi-s-images-released/releases/download/rock-pi-s-v20210924/rockpis_debian_buster_server_arm64_20210924_0412-gpt.img.gz
+          image_additional_mb: 2048
+          cpu: cortex-a53
+          commands: |
+            test $(df -h --output=size / | tail -n 1) = '2.8G'


### PR DESCRIPTION
The [Rock Pi S image](https://github.com/radxa/rock-pi-s-images-released/releases) we're using uses a GPT partition. GPT has a partition table at the beginning _and end_ of the disk unlike a MBR partition table which only has one at the beginning.

This change modifies `mount_image.sh` to detect a GPT partition table and use `sgdisk` to restore the partition table at the end of the disk image after it has increased in size.

When using `partprobe` with GPT it seems the `/dev/loop*` devices are not available synchronously (although they are available very fast) so a `sleep 1` seemed like an appropriate workaround.