### PR TITLE
CPU info for Raspberry Pi 4B

### DIFF
--- a/.github/workflows/test-cpu_info.yml
+++ b/.github/workflows/test-cpu_info.yml
@@ -79,4 +79,4 @@ jobs:
     - name: Test content of cpuinfo
       run: |
         grep -c "CPU architecture: 8" cpuinfo.txt
-        grep -c 1000000018753000 cpuinfo.txt
+        grep -c 676974687562004b cpuinfo.txt

--- a/.github/workflows/test-cpu_info.yml
+++ b/.github/workflows/test-cpu_info.yml
@@ -65,3 +65,18 @@ jobs:
       run: |
         grep -c "CPU architecture: 8" cpuinfo.txt
         grep -c 6769746875620002 cpuinfo.txt
+  test_4b:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ./ # pguyot/arm-runner-action@HEAD
+      with:
+        cpu_info: cpuinfo/raspberrypi_4b
+        bind_mount_repository: true
+        cpu: cortex-a53
+        commands: |
+            cat /proc/cpuinfo > cpuinfo.txt
+    - name: Test content of cpuinfo
+      run: |
+        grep -c "CPU architecture: 8" cpuinfo.txt
+        grep -c 1000000018753000 cpuinfo.txt

--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ used to trick them. The path is relative to the action (to use pre-defined
 settings) or to the local repository.
 
 Bundled with the action are the following files:
+- `cpuinfo/raspberrypi_4b`
 - `cpuinfo/raspberrypi_3b` (with a 32 bits system)
 - `cpuinfo/raspberrypi_zero_w`
 - `cpuinfo/raspberrypi_zero2_w` (with a 32 bits system)

--- a/cpuinfo/raspberrypi_4b
+++ b/cpuinfo/raspberrypi_4b
@@ -1,0 +1,40 @@
+processor	: 0
+BogoMIPS	: 108.00
+Features	: fp asimd evtstrm crc32 cpuid
+CPU implementer	: 0x41
+CPU architecture: 8
+CPU variant	: 0x0
+CPU part	: 0xd08
+CPU revision	: 3
+
+processor	: 1
+BogoMIPS	: 108.00
+Features	: fp asimd evtstrm crc32 cpuid
+CPU implementer	: 0x41
+CPU architecture: 8
+CPU variant	: 0x0
+CPU part	: 0xd08
+CPU revision	: 3
+
+processor	: 2
+BogoMIPS	: 108.00
+Features	: fp asimd evtstrm crc32 cpuid
+CPU implementer	: 0x41
+CPU architecture: 8
+CPU variant	: 0x0
+CPU part	: 0xd08
+CPU revision	: 3
+
+processor	: 3
+BogoMIPS	: 108.00
+Features	: fp asimd evtstrm crc32 cpuid
+CPU implementer	: 0x41
+CPU architecture: 8
+CPU variant	: 0x0
+CPU part	: 0xd08
+CPU revision	: 3
+
+Hardware	: BCM2835
+Revision	: b03112
+Serial		: 1000000018753000
+Model		: Raspberry Pi 4 Model B Rev 1.2

--- a/cpuinfo/raspberrypi_4b
+++ b/cpuinfo/raspberrypi_4b
@@ -36,5 +36,5 @@ CPU revision	: 3
 
 Hardware	: BCM2835
 Revision	: b03112
-Serial		: 1000000018753000
+Serial		: 676974687562004b
 Model		: Raspberry Pi 4 Model B Rev 1.2


### PR DESCRIPTION
This was taken from a 64 Raspberry Pi OS installation on a Raspberry Pi 4B.