### PR TITLE
raspios "latest" images are now .xz (not .zip) archives

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Typical usage to upload an image as an artifact:
         - uses: pguyot/arm-runner-action@v2
           id: build_image
           with:
-            base_image: raspios_lite:2022-01-28
+            base_image: raspios_lite:2022-04-04
             commands: |
                 commands to build image
         - name: Compress the release image
@@ -80,8 +80,10 @@ The following values are allowed:
 - `raspios_lite:2021-05-07`
 - `raspios_lite:2021-10-30`
 - `raspios_lite:2022-01-28`
+- `raspios_lite:2022-04-04`
 - `raspios_lite:latest` (armhf build, *default*)
 - `raspios_lite_arm64:2022-01-28` (arm64)
+- `raspios_lite_arm64:2022-04-04` (arm64)
 - `raspios_lite_arm64:latest` (arm64)
 - `dietpi:rpi_armv6_bullseye`
 - `dietpi:rpi_armv7_bullseye`
@@ -133,7 +135,7 @@ or 64 bits binaries) depend on the image. See _32 and 64 bits_ below.
 
 Source paths(s) inside the image to copy outside after the commands have
 executed. Relative to the `/<repository_name>` directory or the directory
-defined with `copy_repolity_path`. Globs are allowed. To copy multiple paths,
+defined with `copy_repository_path`. Globs are allowed. To copy multiple paths,
 provide a list of paths, separated by semicolons. Default is not to copy.
 
 #### `copy_artifact_dest`

--- a/download_image.sh
+++ b/download_image.sh
@@ -5,14 +5,17 @@ case $1 in
     "raspbian_lite:latest")
         url=https://downloads.raspberrypi.org/raspbian_lite_latest
         uncompress="unzip -u"
+	suffix="img.zip"
     ;;
     "raspios_lite:latest")
         url=https://downloads.raspberrypi.org/raspios_lite_armhf_latest
-        uncompress="unzip -u"
+        uncompress="xz -d"
+	suffix=".img.xz"
     ;;
     "raspios_lite_arm64:latest")
         url=https://downloads.raspberrypi.org/raspios_lite_arm64_latest
-        uncompress="unzip -u"
+        uncompress="xz -d"
+	suffix=".img.xz"
     ;;
     "raspbian_lite:2020-02-13")
         url=https://downloads.raspberrypi.org/raspbian_lite/images/raspbian_lite-2020-02-14/2020-02-13-raspbian-buster-lite.zip
@@ -29,8 +32,14 @@ case $1 in
     "raspios_lite:2022-01-28")
         url=https://downloads.raspberrypi.org/raspios_lite_armhf/images/raspios_lite_armhf-2022-01-28/2022-01-28-raspios-bullseye-armhf-lite.zip
     ;;
+    "raspios_lite:2022-04-04")
+        url=https://downloads.raspberrypi.org/raspios_lite_armhf/images/raspios_lite_armhf-2022-04-07/2022-04-04-raspios-bullseye-armhf-lite.xz
+    ;;
     "raspios_lite_arm64:2022-01-28")
         url=https://downloads.raspberrypi.org/raspios_lite_arm64/images/raspios_lite_arm64-2022-01-28/2022-01-28-raspios-bullseye-arm64-lite.zip
+    ;;
+    "raspios_lite_arm64:2022-04-04")
+        url=https://downloads.raspberrypi.org/raspios_lite_arm64/images/raspios_lite_arm64-2022-04-07/2022-04-04-raspios-bullseye-arm64-lite.xz
     ;;
     "dietpi:rpi_armv6_bullseye")
         url=https://dietpi.com/downloads/images/DietPi_RPi-ARMv6-Bullseye.7z
@@ -65,23 +74,29 @@ esac
 case $url in
     *.zip)
         uncompress="unzip -u"
+	suffix=""
     ;;
     *.7z)
         uncompress="7zr e"
+	suffix=""
     ;;
     *.xz)
         uncompress="xz -d"
+	suffix=""
     ;;
     *.gz)
         uncompress="gzip -d"
+	suffix=""
     ;;
 esac
 
-filename=`basename ${url}`
 tempdir=${RUNNER_TEMP:-/home/actions/temp}/arm-runner
 mkdir -p ${tempdir}
 cd ${tempdir}
+rm -f arm-runner.img
 wget -q ${url}
-${uncompress} ${filename}
+filename=`basename ${url}`
+[ -n "${suffix}" ] && mv ${filename} ${filename}${suffix}
+${uncompress} ${filename}${suffix}
 mv "$(ls *.img */*.img 2>/dev/null | head -n 1)" arm-runner.img
 echo "::set-output name=image::${tempdir}/arm-runner.img"


### PR DESCRIPTION
The `download.sh` script needs to be updated accordingly, taking into account fact that `xz` does not like files without `.xz` extension....