### PR TITLE
add option copy_artifacts_on_fail

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,11 @@ Exit immediately if a command exits with a non-zero status. Default is to exit.
 Set to `no` or `false` to disable exiting on command failure. This only works
 with `sh`, `bash` and `ksh` shells.
 
+#### `copy_artifacts_on_fail`
+
+Copy artifacts if a command exits with a non-zero status. Default is to no copy.
+Set to `yes` to copy artifacts.
+
 #### `debug`
 
 Display executed commands as they are executed. Enabled by default.

--- a/action.yml
+++ b/action.yml
@@ -238,7 +238,7 @@ runs:
         exit $rc
       shell: bash
     - name: Copy artifacts within image
-      if: ${{ always() && inputs.copy_artifacts_on_fail == 'yes' || steps.runcmd.conclusion != 'failure' }}
+      if: ${{ always() && !cancelled() && inputs.copy_artifacts_on_fail == 'yes' || steps.runcmd.conclusion != 'failure' }}
       run: |
         case "${{ inputs.debug }}" in
         yes|true)

--- a/action.yml
+++ b/action.yml
@@ -238,8 +238,8 @@ runs:
         exit $rc
       shell: bash
     - name: Copy artifacts within image
-      if: ${{ always() && !cancelled() && inputs.copy_artifacts_on_fail == 'yes' || steps.runcmd.conclusion != 'failure' }}
-      run: |
+      if: ${{ always() && !cancelled() && (inputs.copy_artifacts_on_fail == 'yes' || steps.runcmd.conclusion == 'success') }}
+       run: |
         case "${{ inputs.debug }}" in
         yes|true)
             set -x

--- a/action.yml
+++ b/action.yml
@@ -64,6 +64,10 @@ inputs:
     description: 'Exit immediately if a command exits with a non-zero status'
     required: false
     default: 'yes'
+  copy_artifacts_on_fail:
+    description: 'Copy artifacts if a command exits with a non-zero status'
+    required: false
+    default: 'no'
   debug:
     description: 'Display commands as they are executed'
     required: false
@@ -138,6 +142,7 @@ runs:
         sudo mount --bind ${cpu_info_path} ${{ steps.mount_image.outputs.mount }}/proc/cpuinfo
       shell: bash
     - name: Run commands
+      id: runcmd
       run: |
         case "${{ inputs.debug }}" in
         yes|true)
@@ -233,6 +238,7 @@ runs:
         exit $rc
       shell: bash
     - name: Copy artifacts within image
+      if: ${{ always() && inputs.copy_artifacts_on_fail == 'yes' || steps.runcmd.conclusion != 'failure' }}
       run: |
         case "${{ inputs.debug }}" in
         yes|true)


### PR DESCRIPTION
- add option to copy artifacts if a command exits with a non-zero status

useful when running tests and want to copy the test result even if the test fail