### PR TITLE
Update broken download URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,9 +100,9 @@ The following values are allowed:
 - `dietpi:rpi_armv7_bullseye`
 - `dietpi:rpi_armv8_bullseye` (arm64)
 - `raspi_1_bullseye:20220121` (armel)
-- `raspi_2_bullseye:20220121` (armhf)
-- `raspi_3_bullseye:20220121` (arm64)
-- `raspi_4_bullseye:20220121` (arm64)
+- `raspi_2_bullseye:20230102` (armhf)
+- `raspi_3_bullseye:20230102` (arm64)
+- `raspi_4_bullseye:20230102` (arm64)
 
 The input parameter also accepts any custom URL beginning in http(s)://...
 

--- a/download_image.sh
+++ b/download_image.sh
@@ -48,13 +48,13 @@ case $1 in
         url=https://raspi.debian.net/tested/20220121_raspi_1_bullseye.img.xz
     ;;
     "raspi_2_bullseye:20220121")
-        url=https://raspi.debian.net/tested/20220121_raspi_2_bullseye.img.xz
+        url=https://raspi.debian.net/tested/20230102_raspi_2_bullseye.img.xz
     ;;
     "raspi_3_bullseye:20220121")
-        url=https://raspi.debian.net/tested/20220121_raspi_3_bullseye.img.xz
+        url=https://raspi.debian.net/tested/20230102_raspi_3_bullseye.img.xz
     ;;
     "raspi_4_bullseye:20220121")
-        url=https://raspi.debian.net/tested/20220121_raspi_4_bullseye.img.xz
+        url=https://raspi.debian.net/tested/20230102_raspi_4_bullseye.img.xz
     ;;
     https:/*|http:/*)
         url="$1"

--- a/download_image.sh
+++ b/download_image.sh
@@ -47,13 +47,13 @@ case $1 in
     "raspi_1_bullseye:20220121")
         url=https://raspi.debian.net/tested/20220121_raspi_1_bullseye.img.xz
     ;;
-    "raspi_2_bullseye:20220121")
+    "raspi_2_bullseye:20230102")
         url=https://raspi.debian.net/tested/20230102_raspi_2_bullseye.img.xz
     ;;
-    "raspi_3_bullseye:20220121")
+    "raspi_3_bullseye:20230102")
         url=https://raspi.debian.net/tested/20230102_raspi_3_bullseye.img.xz
     ;;
-    "raspi_4_bullseye:20220121")
+    "raspi_4_bullseye:20230102")
         url=https://raspi.debian.net/tested/20230102_raspi_4_bullseye.img.xz
     ;;
     https:/*|http:/*)


### PR DESCRIPTION
While attempting to use `raspi_4_bullseye:20220121` for the **base_image**, found that the archive no longer exists at the specified URL since there are newer builds available at this point.

Checked all other URLs and updated two others that were outdated as well.
