### PR TITLE
Update ubuntu 22.04.2 link

### DIFF
--- a/.github/workflows/test-custom-url.yml
+++ b/.github/workflows/test-custom-url.yml
@@ -25,7 +25,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: ./ # pguyot/arm-runner-action@HEAD
       with:
-        base_image: https://cdimage.ubuntu.com/releases/22.04.1/release/ubuntu-22.04.1-preinstalled-server-arm64+raspi.img.xz
+        base_image: https://cdimage.ubuntu.com/releases/22.04.2/release/ubuntu-22.04.2-preinstalled-server-arm64+raspi.img.xz
         commands: |
           cat /etc/os-release
           uname -a


### PR DESCRIPTION
The old 22.04.1 link does not exist, update to the recent Ubuntu 22.04.2 link.