### PR TITLE
Enforce bootpartition to be different from rootpartition

### DIFF
--- a/mount_image.sh
+++ b/mount_image.sh
@@ -8,6 +8,13 @@ rootpartition=$4
 
 if [ $# -ge 5 ]; then
     bootpartition=$5
+    if [ "x$rootpartition" = "x$bootpartition" ]; then
+        echo "Boot partition cannot be equal to root partition"
+        if [ "x$bootpartition" = "x1" ]; then
+            echo "Forgot to unset bootpartition ?"
+        fi
+        exit 1
+    fi
 else
     bootpartition=
 fi


### PR DESCRIPTION
Avoid errors when rootpartition is set to 1 but bootpartition is not unset.
