### PR TITLE
update "latest" Rapsberry Pi OS Lite

### DIFF
--- a/download_image.sh
+++ b/download_image.sh
@@ -3,7 +3,7 @@ set -uo pipefail
 
 case $1 in
     "raspbian_lite:latest")
-        url=https://downloads.raspberrypi.org/raspbian_lite_latest
+        url=https://downloads.raspberrypi.org/raspios_lite_armhf/images/raspios_lite_armhf-2023-05-03/2023-05-03-raspios-bullseye-armhf-lite.img.xz
     ;;
     "raspios_lite:latest")
         url=https://downloads.raspberrypi.org/raspios_lite_armhf_latest


### PR DESCRIPTION
The URL for the currently latest version of Raspberry Pi OS Lite has changed. The current one does no longer work. With this PR, it will be possible to use the latest version of Raspberry Pi OS Lite for at least some time.