### PR TITLE
Update and complement DietPi images

### DIFF
--- a/.github/workflows/test-aarch64.yml
+++ b/.github/workflows/test-aarch64.yml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: ./ # pguyot/arm-runner-action@HEAD
       with:
-        base_image: https://dietpi.com/downloads/images/DietPi_RPi-ARMv8-Bullseye.7z
+        base_image: https://dietpi.com/downloads/images/DietPi_RPi-ARMv8-Bookworm.img.xz
         cpu: cortex-a53
         commands: |
             echo "Minimal"

--- a/.github/workflows/test-base_images.yml
+++ b/.github/workflows/test-base_images.yml
@@ -30,17 +30,17 @@ jobs:
           - dietpi:rpi_armv6_bullseye
           - dietpi:rpi_armv7_bullseye
           - dietpi:rpi_armv8_bullseye
+          - dietpi:rpi_armv6_bookworm
+          - dietpi:rpi_armv7_bookworm
+          - dietpi:rpi_armv8_bookworm
           - raspi_1_bullseye:20220121
           - raspi_2_bullseye:20230102
           - raspi_3_bullseye:20230102
           - raspi_4_bullseye:20230102
-          - raspi_1_bookworm:20230612
-          - raspi_2_bookworm:20230102
-          - raspi_2_bookworm:20230612
-          - raspi_3_bookworm:20230102
-          - raspi_3_bookworm:20230612
-          - raspi_4_bookworm:20230101
-          - raspi_4_bookworm:20230612
+          - raspi_1_bookworm:20231109
+          - raspi_2_bookworm:20231109
+          - raspi_3_bookworm:20231109
+          - raspi_4_bookworm:20231109
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test-custom-url.yml
+++ b/.github/workflows/test-custom-url.yml
@@ -25,7 +25,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: ./ # pguyot/arm-runner-action@HEAD
       with:
-        base_image: https://cdimage.ubuntu.com/releases/23.04/release/ubuntu-23.04-preinstalled-server-arm64+raspi.img.xz
+        base_image: https://cdimage.ubuntu.com/releases/22.04.4/release/ubuntu-22.04.4-preinstalled-server-arm64+raspi.img.xz
         commands: |
           cat /etc/os-release
           uname -a

--- a/.github/workflows/test-partitions.yml
+++ b/.github/workflows/test-partitions.yml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: ./ # pguyot/arm-runner-action@HEAD
       with:
-        base_image: https://developer.nvidia.com/embedded/l4t/r32_release_v7.1/jp_4.6.1_b110_sd_card/jetson_xavier_nx/jetson-nx-jp461-sd-card-image.zip
+        base_image: https://developer.nvidia.com/embedded/L4T/r35_Release_v1.0/JP_SD_5.0.2_b231/Jetson_SD_Xavier_NX/JP502-xnx-sd-card-image-b231.zip
         cpu: cortex-a53
         bootpartition:
         rootpartition: 1

--- a/README.md
+++ b/README.md
@@ -102,17 +102,17 @@ The following values are allowed:
 -   `dietpi:rpi_armv6_bullseye`
 -   `dietpi:rpi_armv7_bullseye`
 -   `dietpi:rpi_armv8_bullseye` (arm64)
+-   `dietpi:rpi_armv6_bookworm`
+-   `dietpi:rpi_armv7_bookworm`
+-   `dietpi:rpi_armv8_bookworm` (arm64)
 -   `raspi_1_bullseye:20220121` (armel)
 -   `raspi_2_bullseye:20230102` (armhf)
 -   `raspi_3_bullseye:20230102` (arm64)
 -   `raspi_4_bullseye:20230102` (arm64)
--   `raspi_1_bookworm:20230612` (armel)
--   `raspi_2_bookworm:20230102` (armhf)
--   `raspi_2_bookworm:20230612` (armhf)
--   `raspi_3_bookworm:20230102` (arm64)
--   `raspi_3_bookworm:20230612` (arm64)
--   `raspi_4_bookworm:20230101` (arm64)
--   `raspi_4_bookworm:20230612` (arm64)
+-   `raspi_1_bookworm:20231109` (armel)
+-   `raspi_2_bookworm:20231109` (armhf)
+-   `raspi_3_bookworm:20231109` (arm64)
+-   `raspi_4_bookworm:20231109` (arm64)
 
 The input parameter also accepts any custom URL beginning in http(s)://...
 

--- a/download_image.sh
+++ b/download_image.sh
@@ -45,46 +45,46 @@ case $1 in
         url=https://downloads.raspberrypi.org/raspios_lite_arm64/images/raspios_lite_arm64-2023-05-03/2023-05-03-raspios-bullseye-arm64-lite.img.xz
     ;;
     "dietpi:rpi_armv6_bullseye")
-        url=https://dietpi.com/downloads/images/DietPi_RPi-ARMv6-Bullseye.7z
+        url=https://dietpi.com/downloads/images/DietPi_RPi-ARMv6-Bullseye.img.xz
     ;;
     "dietpi:rpi_armv7_bullseye")
-        url=https://dietpi.com/downloads/images/DietPi_RPi-ARMv7-Bullseye.7z
+        url=https://dietpi.com/downloads/images/DietPi_RPi-ARMv7-Bullseye.img.xz
     ;;
     "dietpi:rpi_armv8_bullseye")
-        url=https://dietpi.com/downloads/images/DietPi_RPi-ARMv8-Bullseye.7z
+        url=https://dietpi.com/downloads/images/DietPi_RPi-ARMv8-Bullseye.img.xz
+    ;;
+    "dietpi:rpi_armv6_bookworm")
+        url=https://dietpi.com/downloads/images/DietPi_RPi-ARMv6-Bookworm.img.xz
+    ;;
+    "dietpi:rpi_armv7_bookworm")
+        url=https://dietpi.com/downloads/images/DietPi_RPi-ARMv7-Bookworm.img.xz
+    ;;
+    "dietpi:rpi_armv8_bookworm")
+        url=https://dietpi.com/downloads/images/DietPi_RPi-ARMv8-Bookworm.img.xz
     ;;
     "raspi_1_bullseye:20220121")
         url=https://raspi.debian.net/tested/20220121_raspi_1_bullseye.img.xz
     ;;
-    "raspi_1_bookworm:20230612")
-        url=https://raspi.debian.net/tested/20230612_raspi_1_bookworm.img.xz
+    "raspi_1_bookworm:20231109")
+        url=https://raspi.debian.net/tested/20231109_raspi_1_bookworm.img.xz
     ;;
     "raspi_2_bullseye:20230102")
         url=https://raspi.debian.net/tested/20230102_raspi_2_bullseye.img.xz
     ;;
-    "raspi_2_bookworm:20230102")
-        url=https://raspi.debian.net/tested/20230102_raspi_2_bookworm.img.xz
-    ;;
-    "raspi_2_bookworm:20230612")
-        url=https://raspi.debian.net/tested/20230612_raspi_2_bookworm.img.xz
+    "raspi_2_bookworm:20231109")
+        url=https://raspi.debian.net/tested/20231109_raspi_2_bookworm.img.xz
     ;;
     "raspi_3_bullseye:20230102")
         url=https://raspi.debian.net/tested/20230102_raspi_3_bullseye.img.xz
     ;;
-    "raspi_3_bookworm:20230102")
-        url=https://raspi.debian.net/tested/20230102_raspi_3_bookworm.img.xz
-    ;;
-    "raspi_3_bookworm:20230612")
-        url=https://raspi.debian.net/tested/20230612_raspi_3_bookworm.img.xz
+    "raspi_3_bookworm:20231109")
+        url=https://raspi.debian.net/tested/20231109_raspi_3_bookworm.img.xz
     ;;
     "raspi_4_bullseye:20230102")
         url=https://raspi.debian.net/tested/20230102_raspi_4_bullseye.img.xz
     ;;
-    "raspi_4_bookworm:20230101")
-        url=https://raspi.debian.net/tested/20230101_raspi_4_bookworm.img.xz
-    ;;
-    "raspi_4_bookworm:20230612")
-        url=https://raspi.debian.net/tested/20230612_raspi_4_bookworm.img.xz
+    "raspi_4_bookworm:20231109")
+        url=https://raspi.debian.net/tested/20231109_raspi_4_bookworm.img.xz
     ;;
     https:/*|http:/*)
         url="$1"


### PR DESCRIPTION
DietPi provides images in xz-compressed format in the meantime, and images based on Debian Bookworm: https://dietpi.com/downloads/images/