### PR TITLE
Enabling OverlayFS in image does not work

### DIFF
--- a/.github/workflows/test-overlayfs.yml
+++ b/.github/workflows/test-overlayfs.yml
@@ -1,0 +1,34 @@
+name: Test overlayfs
+on:
+  push:
+    branches:
+      - 'main'
+      - 'releases/**'
+      - 'test-overlayfs'
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  test_overlayfs:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - uses: ./ # pguyot/arm-runner-action@HEAD
+      id: enable_overlayfs
+      with:
+        # we don't want to optimize as it's two-stage
+        optimize_image: no
+        commands: |
+          sudo raspi-config nonint do_overlayfs 0
+    
+    - name: Compress image and generate release JSON
+      run: |
+        mv "${{ steps.enable_overlayfs.outputs.image }}" "${{ runner.temp }}/overlayfs.img"
+        pigz -kf "${{ runner.temp }}/overlayfs.img"
+    
+    - uses: actions/upload-artifact@v4
+      with:
+        name: overlayfs.img.gz
+        path: ${{ runner.temp }}/overlayfs.img.gz
+        retention-days: 5


### PR DESCRIPTION
I am trying to generate images which have OverlayFS enabled so the image created is in a read-only mode when first booted. I am running `raspi-config nonint do_overlayfs 0` which enables OverlayFS by adding a parameter to the `cmdfile.txt`. This should then enable overlayfs on first boot.

When I boot and run `mount`, I am not seeing the overlayfs mount:

```
$ mount
sysfs on /sys type sysfs (rw,nosuid,nodev,noexec,relatime)
proc on /proc type proc (rw,relatime)
udev on /dev type devtmpfs (rw,nosuid,relatime,size=1671536k,nr_inodes=417884,mode=755)
devpts on /dev/pts type devpts (rw,nosuid,noexec,relatime,gid=5,mode=620,ptmxmode=000)
tmpfs on /run type tmpfs (rw,nosuid,nodev,noexec,relatime,size=388308k,mode=755)
/dev/mmcblk0p2 on / type ext4 (rw,noatime)
securityfs on /sys/kernel/security type securityfs (rw,nosuid,nodev,noexec,relatime)
tmpfs on /dev/shm type tmpfs (rw,nosuid,nodev)
tmpfs on /run/lock type tmpfs (rw,nosuid,nodev,noexec,relatime,size=5120k)
cgroup2 on /sys/fs/cgroup type cgroup2 (rw,nosuid,nodev,noexec,relatime,nsdelegate,memory_recursiveprot)
pstore on /sys/fs/pstore type pstore (rw,nosuid,nodev,noexec,relatime)
bpf on /sys/fs/bpf type bpf (rw,nosuid,nodev,noexec,relatime,mode=700)
systemd-1 on /proc/sys/fs/binfmt_misc type autofs (rw,relatime,fd=29,pgrp=1,timeout=0,minproto=5,maxproto=5,direct,pipe_ino=5454)
mqueue on /dev/mqueue type mqueue (rw,nosuid,nodev,noexec,relatime)
debugfs on /sys/kernel/debug type debugfs (rw,nosuid,nodev,noexec,relatime)
tracefs on /sys/kernel/tracing type tracefs (rw,nosuid,nodev,noexec,relatime)
fusectl on /sys/fs/fuse/connections type fusectl (rw,nosuid,nodev,noexec,relatime)
ramfs on /run/credentials/systemd-sysctl.service type ramfs (ro,nosuid,nodev,noexec,relatime,mode=700)
configfs on /sys/kernel/config type configfs (rw,nosuid,nodev,noexec,relatime)
ramfs on /run/credentials/systemd-sysusers.service type ramfs (ro,nosuid,nodev,noexec,relatime,mode=700)
ramfs on /run/credentials/systemd-tmpfiles-setup-dev.service type ramfs (ro,nosuid,nodev,noexec,relatime,mode=700)
/dev/mmcblk0p1 on /boot/firmware type vfat (ro,relatime,fmask=0022,dmask=0022,codepage=437,iocharset=ascii,shortname=mixed,errors=remount-ro)
ramfs on /run/credentials/systemd-tmpfiles-setup.service type ramfs (ro,nosuid,nodev,noexec,relatime,mode=700)
sunrpc on /run/rpc_pipefs type rpc_pipefs (rw,relatime)
binfmt_misc on /proc/sys/fs/binfmt_misc type binfmt_misc (rw,nosuid,nodev,noexec,relatime)
tmpfs on /run/user/1000 type tmpfs (rw,nosuid,nodev,relatime,size=388304k,nr_inodes=97076,mode=700,uid=1000,gid=1000)
```

I can get it working by booting for the first time, running these commands, and then rebooting:

```
sudo mount -o rw,remount /boot/firmware
sudo apt reinstall overlayroot
```

At that point overlayfs appears correctly in the mounts and any filesystem changes are forgotten on reboot.

I have added a test Github Action workflow which generates an image and uploads it as an image. You can boot this on a physical pi to see the behaviour.

I'm not really sure how to resolve this currently. Do you have any suggestions for how this might be achieved?