### PR TITLE
Add non_image_commands to action

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ deleted on cleanup.
 
 ### Inputs
 
+#### `non_image_commands`
+
+Commands to execute outside the image after the repo has been copied/mounted into the image, but before the image commands run. Optional.
+
 #### `commands`
 
 Commands to execute. Written to a script within the image. Required.

--- a/action.yml
+++ b/action.yml
@@ -148,13 +148,13 @@ runs:
       id: cache_base_image
       uses: actions/cache@v3
       with:
-        path: cached_base_images
+        path: /home/runner/work/cached_base_images
         key: base-image-${{ inputs.base_image }}
     - name: Download base image
       id: download_image
       run: |
         set -e
-        CACHE_DIR="cached_base_images"
+        CACHE_DIR="/home/runner/work/cached_base_images"
         mkdir -p "$CACHE_DIR"
         # Sanitize the base image name to create a valid filename.
         BASE_IMAGE_FILENAME=$(echo "${{ inputs.base_image }}" | sed 's/[^a-zA-Z0-9_.-]/_/g').img

--- a/action.yml
+++ b/action.yml
@@ -222,7 +222,7 @@ runs:
             sudo cp -Rp ${{ github.workspace }} ${{ steps.mount_image.outputs.mount }}${repository_path}
         ;;
         esac
-        if [ "${{ inputs.non_image_commands }}x" != "x" ]; then
+        if [ -n "${{ inputs.non_image_commands }}" ]; then
             script_path=${script_dir}/non_image_commands.sh
             mkdir -p ${script_dir}
             cat >> ${script_path} <<"INPUT_COMMANDS_EOF"

--- a/action.yml
+++ b/action.yml
@@ -223,11 +223,11 @@ runs:
         ;;
         esac
         if [ "${{ inputs.non_image_commands }}x" != "x" ]; then
-            mkdir -p ${script_dir}
             script_path=${script_dir}/non_image_commands.sh
+            mkdir -p ${script_dir}
             cat >> ${script_path} <<"INPUT_COMMANDS_EOF"
-            ${{ inputs.non_image_commands }}
-            INPUT_COMMANDS_EOF
+        ${{ inputs.non_image_commands }}
+        INPUT_COMMANDS_EOF
             /bin/sh $script_path
         fi
         if [ "${{ inputs.use_systemd_nspawn }}x" != "x" -a "${{ inputs.use_systemd_nspawn }}x" != "nox" ]; then

--- a/action.yml
+++ b/action.yml
@@ -259,6 +259,10 @@ runs:
           if [ -z "$extra_files_mnt_path" ]; then
             extra_files_mnt_path="/"
           fi
+          
+          # Ensure path starts with a slash and doesn't have double slashes
+          extra_files_mnt_path=$(echo "/${extra_files_mnt_path}" | sed 's#^//*#/#')
+          
           echo "Copying extra files from ${{ inputs.extra_files_path }} to ${{ steps.mount_image.outputs.mount }}${extra_files_mnt_path}"
           sudo mkdir -p "${{ steps.mount_image.outputs.mount }}${extra_files_mnt_path}"
           sudo cp -Rp ${{ inputs.extra_files_path }}/* "${{ steps.mount_image.outputs.mount }}${extra_files_mnt_path}/"

--- a/action.yml
+++ b/action.yml
@@ -144,12 +144,30 @@ runs:
         sudo update-binfmts --package arm-runner-action --install arm-runner-action-qemu-arm1 /usr/bin/qemu-arm-static0 --magic '\x7f\x45\x4c\x46\x01\x01\x01\x00\x41\x49\x02\x00\x00\x00\x00\x00\x02\x00\x28\x00' --mask '\xff\xff\xff\xff\xff\xff\xff\x00\xff\xff\xff\xff\xff\xff\xff\xff\xfe\xff\xff\xff' --credentials yes --fix-binary yes
         sudo update-binfmts --package arm-runner-action --install arm-runner-action-qemu-aarch64 /usr/bin/qemu-aarch64-static0 --magic '\x7f\x45\x4c\x46\x02\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\xb7\x00' --mask '\xff\xff\xff\xff\xff\xff\xff\x00\xff\xff\xff\xff\xff\xff\xff\xff\xfe\xff\xff\xff' --credentials yes --fix-binary yes
         sudo update-binfmts --package arm-runner-action --install arm-runner-action-qemu-aarch641 /usr/bin/qemu-aarch64-static0 --magic '\x7f\x45\x4c\x46\x02\x01\x01\x00\x41\x49\x02\x00\x00\x00\x00\x00\x02\x00\xb7\x00' --mask '\xff\xff\xff\xff\xff\xff\xff\x00\xff\xff\xff\xff\xff\xff\xff\xff\xfe\xff\xff\xff' --credentials yes --fix-binary yes
-
+    - name: Restore base image cache
+      id: cache_base_image
+      uses: actions/cache@v3
+      with:
+        path: cached_base_images
+        key: base-image-${{ inputs.base_image }}
     - name: Download base image
-      run: |
-        bash ${GITHUB_ACTION_PATH}/download_image.sh ${{ inputs.base_image }}
-      shell: bash
       id: download_image
+      run: |
+        set -e
+        CACHE_DIR="cached_base_images"
+        mkdir -p "$CACHE_DIR"
+        # Sanitize the base image name to create a valid filename.
+        BASE_IMAGE_FILENAME=$(echo "${{ inputs.base_image }}" | sed 's/[^a-zA-Z0-9_.-]/_/g').img
+        CACHE_IMAGE_PATH="$CACHE_DIR/$BASE_IMAGE_FILENAME"
+        if [ -f "$CACHE_IMAGE_PATH" ]; then
+          echo "Base image found in cache: $CACHE_IMAGE_PATH"
+        else
+          echo "Downloading base image: ${{ inputs.base_image }}"
+          DOWNLOADED_IMAGE=$(bash ${GITHUB_ACTION_PATH}/download_image.sh "${{ inputs.base_image }}")
+          cp "$DOWNLOADED_IMAGE" "$CACHE_IMAGE_PATH"
+        fi
+        echo "::set-output name=image::$CACHE_IMAGE_PATH"
+      shell: bash
     - name: Mount and optionally resize image
       run: |
         sudo --preserve-env=GITHUB_OUTPUT bash ${GITHUB_ACTION_PATH}/mount_image.sh ${{ steps.download_image.outputs.image }} ${{ inputs.image_additional_mb }} ${{ inputs.use_systemd_nspawn }} ${{ inputs.rootpartition }} ${{ inputs.bootpartition }}

--- a/action.yml
+++ b/action.yml
@@ -223,7 +223,12 @@ runs:
         ;;
         esac
         if [ "${{ inputs.non_image_commands }}x" != "x" ]; then
+            mkdir -p ${script_dir}
+            script_path=${script_dir}/non_image_commands.sh
+            cat >> ${script_path} <<"INPUT_COMMANDS_EOF"
             ${{ inputs.non_image_commands }}
+            INPUT_COMMANDS_EOF
+            /bin/sh $script_path
         fi
         if [ "${{ inputs.use_systemd_nspawn }}x" != "x" -a "${{ inputs.use_systemd_nspawn }}x" != "nox" ]; then
             chroot_script_dir=/scripts

--- a/action.yml
+++ b/action.yml
@@ -253,7 +253,18 @@ runs:
         ;;
         esac
         if [ -n "${{ inputs.extra_files_path }}" ]; then
-          sudo cp -Rp ${{ inputs.extra_files_path }} ${{ steps.mount_image.outputs.mount }}${inputs.extra_files_mnt_path}
+          # Create target directory if needed
+          extra_files_mnt_path="${{ inputs.extra_files_mnt_path }}"
+          # Default to copying to root if not specified
+          if [ -z "$extra_files_mnt_path" ]; then
+            extra_files_mnt_path="/"
+          fi
+          echo "Copying extra files from ${{ inputs.extra_files_path }} to ${{ steps.mount_image.outputs.mount }}${extra_files_mnt_path}"
+          sudo mkdir -p "${{ steps.mount_image.outputs.mount }}${extra_files_mnt_path}"
+          sudo cp -Rp ${{ inputs.extra_files_path }}/* "${{ steps.mount_image.outputs.mount }}${extra_files_mnt_path}/"
+          # List contents to verify copy
+          echo "Contents of ${{ steps.mount_image.outputs.mount }}${extra_files_mnt_path}:"
+          sudo ls -la "${{ steps.mount_image.outputs.mount }}${extra_files_mnt_path}"
         fi
         if [ "${{ inputs.use_systemd_nspawn }}x" != "x" -a "${{ inputs.use_systemd_nspawn }}x" != "nox" ]; then
             chroot_script_dir=/scripts

--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,9 @@ inputs:
     description: 'Path to cpu info file to be mounted on /proc/cpuinfo'
     required: false
     default: ''
+  non_image_commands:
+    description: 'Commands to run outside the image, executed with /bin/sh'
+    required: false
   commands:
     description: 'Commands to run in the image, executed with /bin/sh'
     required: true
@@ -219,6 +222,9 @@ runs:
             sudo cp -Rp ${{ github.workspace }} ${{ steps.mount_image.outputs.mount }}${repository_path}
         ;;
         esac
+        if [ "${{ inputs.non_image_commands }}x" != "x" ]; then
+            ${{ inputs.non_image_commands }}
+        fi
         if [ "${{ inputs.use_systemd_nspawn }}x" != "x" -a "${{ inputs.use_systemd_nspawn }}x" != "nox" ]; then
             chroot_script_dir=/scripts
             script_dir=${RUNNER_TEMP:-/home/actions/temp}/scripts

--- a/action.yml
+++ b/action.yml
@@ -161,12 +161,18 @@ runs:
         CACHE_IMAGE_PATH="$CACHE_DIR/$BASE_IMAGE_FILENAME"
         if [ -f "$CACHE_IMAGE_PATH" ]; then
           echo "Base image found in cache: $CACHE_IMAGE_PATH"
+          echo "image=$CACHE_IMAGE_PATH" >> "$GITHUB_OUTPUT"
         else
           echo "Downloading base image: ${{ inputs.base_image }}"
-          DOWNLOADED_IMAGE=$(bash ${GITHUB_ACTION_PATH}/download_image.sh "${{ inputs.base_image }}")
+          bash ${GITHUB_ACTION_PATH}/download_image.sh "${{ inputs.base_image }}"
+          # Read the last line starting with "image=" from GITHUB_OUTPUT to get the downloaded image path.
+          DOWNLOADED_IMAGE=$(grep '^image=' "$GITHUB_OUTPUT" | tail -n1 | cut -d'=' -f2)
+          if [ -z "$DOWNLOADED_IMAGE" ]; then
+            echo "Error: download_image.sh did not output a valid image path."
+            exit 1
+          fi
           cp "$DOWNLOADED_IMAGE" "$CACHE_IMAGE_PATH"
         fi
-        echo "::set-output name=image::$CACHE_IMAGE_PATH"
       shell: bash
     - name: Mount and optionally resize image
       run: |

--- a/action.yml
+++ b/action.yml
@@ -252,14 +252,8 @@ runs:
             sudo cp -Rp ${{ github.workspace }} ${{ steps.mount_image.outputs.mount }}${repository_path}
         ;;
         esac
-        sudo cp -Rp ${{ inputs.extra_files_path }} ${{ steps.mount_image.outputs.mount }}${inputs.extra_files_mnt_path}
-        # if [ -n "${{ inputs.non_image_commands }}" ]; then
-        #     script_path=${script_dir}/non_image_commands.sh
-        #     mkdir -p ${script_dir}
-        #     cat >> ${script_path} <<"INPUT_COMMANDS_EOF"
-        # ${{ inputs.non_image_commands }}
-        INPUT_COMMANDS_EOF
-            /bin/sh $script_path
+        if [ -n "${{ inputs.extra_files_path }}" ]; then
+          sudo cp -Rp ${{ inputs.extra_files_path }} ${{ steps.mount_image.outputs.mount }}${inputs.extra_files_mnt_path}
         fi
         if [ "${{ inputs.use_systemd_nspawn }}x" != "x" -a "${{ inputs.use_systemd_nspawn }}x" != "nox" ]; then
             chroot_script_dir=/scripts

--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,12 @@ inputs:
     description: 'Path to cpu info file to be mounted on /proc/cpuinfo'
     required: false
     default: ''
+  extra_files_path:
+    description: 'Extra files to copy to the image'
+    required: false
+  extra_files_mnt_path:
+    description: 'Where to copy extra files to in the image'
+    required: false
   non_image_commands:
     description: 'Commands to run outside the image, executed with /bin/sh'
     required: false
@@ -222,11 +228,12 @@ runs:
             sudo cp -Rp ${{ github.workspace }} ${{ steps.mount_image.outputs.mount }}${repository_path}
         ;;
         esac
-        if [ -n "${{ inputs.non_image_commands }}" ]; then
-            script_path=${script_dir}/non_image_commands.sh
-            mkdir -p ${script_dir}
-            cat >> ${script_path} <<"INPUT_COMMANDS_EOF"
-        ${{ inputs.non_image_commands }}
+        sudo cp -Rp ${{ inputs.extra_files_path }} ${{ steps.mount_image.outputs.mount }}${inputs.extra_files_mnt_path}
+        # if [ -n "${{ inputs.non_image_commands }}" ]; then
+        #     script_path=${script_dir}/non_image_commands.sh
+        #     mkdir -p ${script_dir}
+        #     cat >> ${script_path} <<"INPUT_COMMANDS_EOF"
+        # ${{ inputs.non_image_commands }}
         INPUT_COMMANDS_EOF
             /bin/sh $script_path
         fi


### PR DESCRIPTION
Adds an option for commands to execute outside the image after the repo has been copied/mounted into the image, but before the image commands run.

Still a WIP -- I'm in the process of getting this working for myself. Just opening a PR early for visibility.