### PR TITLE
add an option to allow running on docker-wsl containers, by manual partitions preparation

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -88,6 +88,10 @@ inputs:
     description: 'Exports $GITHUB_ENV from the image environment to subsequent tasks'
     required: false
     default: 'no'
+  manual_partitions:
+    description: 'for docker, this option is required to manually set the partitions'
+    required: false
+    default: 'false'
 outputs:
   image:
     description: "Path to image"
@@ -143,7 +147,7 @@ runs:
       id: download_image
     - name: Mount and optionally resize image
       run: |
-        sudo --preserve-env=GITHUB_OUTPUT bash ${GITHUB_ACTION_PATH}/mount_image.sh ${{ steps.download_image.outputs.image }} ${{ inputs.image_additional_mb }} ${{ inputs.use_systemd_nspawn }} ${{ inputs.rootpartition }} ${{ inputs.bootpartition }}
+        sudo --preserve-env=GITHUB_OUTPUT bash ${GITHUB_ACTION_PATH}/mount_image.sh ${{ steps.download_image.outputs.image }} ${{ inputs.image_additional_mb }} ${{ inputs.use_systemd_nspawn }} ${{ inputs.rootpartition }} ${{ inputs.bootpartition }} ${{ inputs.manual_partitions }}
       shell: bash
       id: mount_image
     - name: Mount CPU info

--- a/mount_image.sh
+++ b/mount_image.sh
@@ -36,15 +36,6 @@ loopdev=$(losetup --find --show --partscan ${image})
 echo "Created loopback device ${loopdev}"
 echo "loopdev=${loopdev}" >> "$GITHUB_OUTPUT"
 
-if [ ${additional_mb} -gt 0 ]; then
-    if ( (parted --script $loopdev print || false) | grep "Partition Table: gpt" > /dev/null); then
-        sgdisk -e "${loopdev}"
-    fi
-    parted --script "${loopdev}" resizepart ${rootpartition} 100%
-    e2fsck -p -f "${loopdev}p${rootpartition}"
-    resize2fs "${loopdev}p${rootpartition}"
-    echo "Finished resizing disk image."
-fi
 
 waitForFile() {
     maxRetries=60
@@ -88,6 +79,16 @@ fi
 
 rootdev=$(waitForFile "${loopdev}p${rootpartition}")
 
+
+if [ ${additional_mb} -gt 0 ]; then
+    if ( (parted --script $loopdev print || false) | grep "Partition Table: gpt" > /dev/null); then
+        sgdisk -e "${loopdev}"
+    fi
+    parted --script "${loopdev}" resizepart ${rootpartition} 100%
+    e2fsck -p -f "${loopdev}p${rootpartition}"
+    resize2fs "${loopdev}p${rootpartition}"
+    echo "Finished resizing disk image."
+fi
 
 # Mount the image
 mount=${RUNNER_TEMP:-/home/actions/temp}/arm-runner/mnt

--- a/mount_image.sh
+++ b/mount_image.sh
@@ -76,15 +76,9 @@ if [ "x$manual_partitions" = "xyes" -o "x$manual_partitions" = "xtrue" ]; then
     done
 
         
-    if [ "x$bootpartition" != "x" ]; then
-        bootdev="${loopdev}p${bootpartition}"
-    else
-        bootdev=
-    fi
 
-    rootdev="${loopdev}p${rootpartition}"
+fi
 
-else
 
 if [ "x$bootpartition" != "x" ]; then
     bootdev=$(waitForFile "${loopdev}p${bootpartition}")
@@ -93,8 +87,6 @@ else
 fi
 
 rootdev=$(waitForFile "${loopdev}p${rootpartition}")
-
-fi
 
 
 # Mount the image


### PR DESCRIPTION
add an option to allow running on docker-wsl containers, by manual partitions preparation.

without this fix, I could not get the partitions to show up. 

the solution is from a comment by [tonyfahrion](https://github.com/tonyfahrion):
https://github.com/moby/moby/issues/27886#issuecomment-417074845
