### PR TITLE
[FIX][DietPi] Update DietPi links

### DIFF
--- a/.github/workflows/test-aarch64.yml
+++ b/.github/workflows/test-aarch64.yml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: ./ # pguyot/arm-runner-action@HEAD
       with:
-        base_image: https://dietpi.com/downloads/images/DietPi_RPi-ARMv8-Bookworm.img.xz
+        base_image: https://dietpi.com/downloads/images/DietPi_RPi5-ARMv8-Bookworm.img.xz
         cpu: cortex-a53
         commands: |
             echo "Minimal"

--- a/.github/workflows/test-base_images.yml
+++ b/.github/workflows/test-base_images.yml
@@ -27,12 +27,18 @@ jobs:
           - raspios_lite_arm64:2023-05-03
           - raspios_lite_arm64:2022-01-28
           - raspios_lite_arm64:2022-04-04
-          - dietpi:rpi_armv6_bullseye
-          - dietpi:rpi_armv7_bullseye
-          - dietpi:rpi_armv8_bullseye
           - dietpi:rpi_armv6_bookworm
           - dietpi:rpi_armv7_bookworm
           - dietpi:rpi_armv8_bookworm
+          - dietpi:rpi5_armv8_bookworm
+          - dietpi:rpi_armv6_trixie
+          - dietpi:rpi_armv7_trixie
+          - dietpi:rpi_armv8_trixie
+          - dietpi:rpi5_armv8_trixie
+          - dietpi:rpi_armv6_forky
+          - dietpi:rpi_armv7_forky
+          - dietpi:rpi_armv8_forky
+          - dietpi:rpi5_armv8_forky
           - raspi_1_bullseye:20220121
           - raspi_2_bullseye:20230102
           - raspi_3_bullseye:20230102

--- a/.github/workflows/test-ipv4-networking.yml
+++ b/.github/workflows/test-ipv4-networking.yml
@@ -15,12 +15,18 @@ jobs:
         image:
           - raspbian_lite:latest
           - raspios_lite:latest
-          - dietpi:rpi_armv6_bullseye
-          - dietpi:rpi_armv7_bullseye
-          - dietpi:rpi_armv8_bullseye
           - dietpi:rpi_armv6_bookworm
           - dietpi:rpi_armv7_bookworm
           - dietpi:rpi_armv8_bookworm
+          - dietpi:rpi5_armv8_bookworm
+          - dietpi:rpi_armv6_trixie
+          - dietpi:rpi_armv7_trixie
+          - dietpi:rpi_armv8_trixie
+          - dietpi:rpi5_armv8_trixie
+          - dietpi:rpi_armv6_forky
+          - dietpi:rpi_armv7_forky
+          - dietpi:rpi_armv8_forky
+          - dietpi:rpi5_armv8_forky
     runs-on: ubuntu-latest
     steps:
     - name: Test native networking

--- a/README.md
+++ b/README.md
@@ -99,12 +99,18 @@ The following values are allowed:
 -   `raspios_lite_arm64:2022-04-04` (arm64)
 -   `raspios_lite_arm64:2023-05-03` (arm64)
 -   `raspios_lite_arm64:latest` (arm64)
--   `dietpi:rpi_armv6_bullseye`
--   `dietpi:rpi_armv7_bullseye`
--   `dietpi:rpi_armv8_bullseye` (arm64)
 -   `dietpi:rpi_armv6_bookworm`
 -   `dietpi:rpi_armv7_bookworm`
 -   `dietpi:rpi_armv8_bookworm` (arm64)
+-   `dietpi:rpi5_armv8_bookworm` (arm64)
+-   `dietpi:rpi_armv6_trixie`
+-   `dietpi:rpi_armv7_trixie`
+-   `dietpi:rpi_armv8_trixie` (arm64)
+-   `dietpi:rpi5_armv8_trixie` (arm64)
+-   `dietpi:rpi_armv6_forky`
+-   `dietpi:rpi_armv7_forky`
+-   `dietpi:rpi_armv8_forky` (arm64)
+-   `dietpi:rpi5_armv8_forky` (arm64)
 -   `raspi_1_bullseye:20220121` (armel)
 -   `raspi_2_bullseye:20230102` (armhf)
 -   `raspi_3_bullseye:20230102` (arm64)

--- a/download_image.sh
+++ b/download_image.sh
@@ -44,23 +44,41 @@ case $1 in
     "raspios_lite_arm64:2023-05-03")
         url=https://downloads.raspberrypi.org/raspios_lite_arm64/images/raspios_lite_arm64-2023-05-03/2023-05-03-raspios-bullseye-arm64-lite.img.xz
     ;;
-    "dietpi:rpi_armv6_bullseye")
-        url=https://dietpi.com/downloads/images/DietPi_RPi-ARMv6-Bullseye.img.xz
-    ;;
-    "dietpi:rpi_armv7_bullseye")
-        url=https://dietpi.com/downloads/images/DietPi_RPi-ARMv7-Bullseye.img.xz
-    ;;
-    "dietpi:rpi_armv8_bullseye")
-        url=https://dietpi.com/downloads/images/DietPi_RPi-ARMv8-Bullseye.img.xz
-    ;;
     "dietpi:rpi_armv6_bookworm")
-        url=https://dietpi.com/downloads/images/DietPi_RPi-ARMv6-Bookworm.img.xz
+        url=https://dietpi.com/downloads/images/DietPi_RPi1-ARMv6-Bookworm.img.xz
     ;;
     "dietpi:rpi_armv7_bookworm")
-        url=https://dietpi.com/downloads/images/DietPi_RPi-ARMv7-Bookworm.img.xz
+        url=https://dietpi.com/downloads/images/DietPi_RPi2-ARMv7-Bookworm.img.xz
     ;;
     "dietpi:rpi_armv8_bookworm")
-        url=https://dietpi.com/downloads/images/DietPi_RPi-ARMv8-Bookworm.img.xz
+        url=https://dietpi.com/downloads/images/DietPi_RPi234-ARMv8-Bookworm.img.xz
+    ;;
+    "dietpi:rpi5_armv8_bookworm")
+        url=https://dietpi.com/downloads/images/DietPi_RPi5-ARMv8-Bookworm.img.xz
+    ;;
+    "dietpi:rpi_armv6_trixie")
+        url=https://dietpi.com/downloads/images/DietPi_RPi1-ARMv6-Trixie.img.xz
+    ;;
+    "dietpi:rpi_armv7_trixie")
+        url=https://dietpi.com/downloads/images/DietPi_RPi2-ARMv7-Trixie.img.xz
+    ;;
+    "dietpi:rpi_armv8_trixie")
+        url=https://dietpi.com/downloads/images/DietPi_RPi234-ARMv8-Trixie.img.xz
+    ;;
+    "dietpi:rpi5_armv8_trixie")
+        url=https://dietpi.com/downloads/images/DietPi_RPi5-ARMv8-Trixie.img.xz
+    ;;
+    "dietpi:rpi_armv6_forky")
+        url=https://dietpi.com/downloads/images/DietPi_RPi1-ARMv6-Forky.img.xz
+    ;;
+    "dietpi:rpi_armv7_forky")
+        url=https://dietpi.com/downloads/images/DietPi_RPi2-ARMv7-Forky.img.xz
+    ;;
+    "dietpi:rpi_armv8_forky")
+        url=https://dietpi.com/downloads/images/DietPi_RPi234-ARMv8-Forky.img.xz
+    ;;
+    "dietpi:rpi5_armv8_forky")
+        url=https://dietpi.com/downloads/images/DietPi_RPi5-ARMv8-Forky.img.xz
     ;;
     "raspi_1_bullseye:20220121")
         url=https://raspi.debian.net/tested/20220121_raspi_1_bullseye.img.xz


### PR DESCRIPTION
Bonjour, @pguyot 

Il semblerait que les liens pour télécharger les images DietPi aient changé :

- Suppression de la version Bullseye (introuvable sur https://dietpi.com/downloads/images/)
- Mise à jour des liens pour Bookworm
- Ajout des versions Trixie et Forky

EDIT 
Cela bloque notamment la génération d'images DietPi pour [nabaztag2018/pynab](https://github.com/nabaztag2018/pynab). Cependant, avec tous les différents workflows qui se sont lancés avec la MR, je ne sais pas s'il reste des choses à corriger.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added DietPi Trixie and Forky image options across Raspberry Pi models.
  * Added Raspberry Pi 5 Bookworm image support.
  * Bookworm downloads now offer model-specific image variants for better hardware compatibility.

* **Bug Fixes / Changes**
  * Removed older Bullseye DietPi image variants from the available options to simplify choices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->